### PR TITLE
Don't be prescriptive on reqwest patch releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ url = { version = "2", features = ["serde"] }
 [dependencies.reqwest]
 default-features = false
 features = ["json"]
-version = "0.11.12"
+version = "0.11"
 
 [features]
 default = ["reqwest/rustls-tls"]


### PR DESCRIPTION
Old reqwest seems to be pulling an ancient tokio release which is causing issues: ```thread 'main' panicked at 'not currently running on a Tokio 0.2.x runtime.'```